### PR TITLE
feat: use fixed version for mach verifier docker image

### DIFF
--- a/ethereum/mach-avs/dodochain-testnet/.env.example
+++ b/ethereum/mach-avs/dodochain-testnet/.env.example
@@ -4,7 +4,7 @@
 
 # TODO: use fixed version of image
 MAIN_SERVICE_IMAGE=public.ecr.aws/altlayer/mach-operator:v0.1.8
-MACH_VERIFIER_IMAGE=public.ecr.aws/altlayer/mach:latest
+MACH_VERIFIER_IMAGE=public.ecr.aws/altlayer/mach:v0.2.0
 
 MACH_SERVICE_NAME=mach-avs-ethereum-dodochain
 

--- a/ethereum/mach-avs/dodochain/.env.example
+++ b/ethereum/mach-avs/dodochain/.env.example
@@ -4,7 +4,7 @@
 
 # TODO: use fixed version of image
 MAIN_SERVICE_IMAGE=public.ecr.aws/altlayer/mach-operator:v0.1.8
-MACH_VERIFIER_IMAGE=public.ecr.aws/altlayer/mach:latest
+MACH_VERIFIER_IMAGE=public.ecr.aws/altlayer/mach:v0.2.0
 
 MACH_SERVICE_NAME=mach-avs-ethereum-dodochain
 

--- a/ethereum/mach-avs/optimism/.env.example
+++ b/ethereum/mach-avs/optimism/.env.example
@@ -4,7 +4,7 @@
 
 # TODO: use fixed version of image
 MAIN_SERVICE_IMAGE=public.ecr.aws/altlayer/mach-operator:v0.1.8
-MACH_VERIFIER_IMAGE=public.ecr.aws/altlayer/mach:latest
+MACH_VERIFIER_IMAGE=public.ecr.aws/altlayer/mach:v0.2.0
 
 MACH_SERVICE_NAME=mach-avs-ethereum-optimism
 

--- a/ethereum/mach-avs/xterio/.env.example
+++ b/ethereum/mach-avs/xterio/.env.example
@@ -4,7 +4,7 @@
 
 # TODO: use fixed version of image
 MAIN_SERVICE_IMAGE=public.ecr.aws/altlayer/mach-operator:v0.1.8
-MACH_VERIFIER_IMAGE=public.ecr.aws/altlayer/mach:latest
+MACH_VERIFIER_IMAGE=public.ecr.aws/altlayer/mach:v0.2.0
 
 MACH_SERVICE_NAME=mach-avs-ethereum-xterio
 

--- a/holesky/mach-avs/cyber-testnet/.env.example
+++ b/holesky/mach-avs/cyber-testnet/.env.example
@@ -4,7 +4,7 @@
 
 # TODO: use fixed version of image
 MAIN_SERVICE_IMAGE=public.ecr.aws/altlayer/mach-operator:v0.1.8
-MACH_VERIFIER_IMAGE=public.ecr.aws/altlayer/mach:latest
+MACH_VERIFIER_IMAGE=public.ecr.aws/altlayer/mach:v0.2.0
 PROXY_SERVICE_NAME=mach-avs-holesky-cyber-testnet-proxy
 NETWORK_NAME=mach-avs-holesky-cyber-testnet-network
 MAIN_SERVICE_NAME=mach-avs-holesky-cyber-testnet-operator-node

--- a/holesky/mach-avs/gmnetwork-testnet/.env.example
+++ b/holesky/mach-avs/gmnetwork-testnet/.env.example
@@ -4,7 +4,7 @@
 
 # TODO: use fixed version of image
 MAIN_SERVICE_IMAGE=public.ecr.aws/altlayer/mach-operator:v0.1.8
-MACH_VERIFIER_IMAGE=public.ecr.aws/altlayer/mach:latest
+MACH_VERIFIER_IMAGE=public.ecr.aws/altlayer/mach:v0.2.0
 
 MACH_SERVICE_NAME=mach-avs-holesky-gmnetwork
 

--- a/holesky/mach-avs/op-sepolia/.env.example
+++ b/holesky/mach-avs/op-sepolia/.env.example
@@ -4,7 +4,7 @@
 
 # TODO: use fixed version of image
 MAIN_SERVICE_IMAGE=public.ecr.aws/altlayer/mach-operator:v0.1.8
-MACH_VERIFIER_IMAGE=public.ecr.aws/altlayer/mach:latest
+MACH_VERIFIER_IMAGE=public.ecr.aws/altlayer/mach:v0.2.0
 
 MACH_SERVICE_NAME=mach-avs-holesky-op-sepolia
 

--- a/holesky/mach-avs/xterio-testnet/.env.example
+++ b/holesky/mach-avs/xterio-testnet/.env.example
@@ -4,7 +4,7 @@
 
 # TODO: use fixed version of image
 MAIN_SERVICE_IMAGE=public.ecr.aws/altlayer/mach-operator:v0.1.8
-MACH_VERIFIER_IMAGE=public.ecr.aws/altlayer/mach:latest
+MACH_VERIFIER_IMAGE=public.ecr.aws/altlayer/mach:v0.2.0
 
 MACH_SERVICE_NAME=mach-avs-holesky-xterio-testnet
 


### PR DESCRIPTION
In next mach verifier, the config will not work, so we need keep this to fixed version.