### PR TITLE
feat: upgrade mach verifier to v0.3.1 for testnet

### DIFF
--- a/ethereum/mach-avs/cyber/.env.example
+++ b/ethereum/mach-avs/cyber/.env.example
@@ -4,7 +4,7 @@
 
 # TODO: use fixed version of image
 MAIN_SERVICE_IMAGE=public.ecr.aws/altlayer/mach-operator:v0.2.2
-MACH_VERIFIER_IMAGE=public.ecr.aws/altlayer/mach:v0.2.1
+MACH_VERIFIER_IMAGE=public.ecr.aws/altlayer/mach:v0.3.1
 
 MACH_SERVICE_NAME=mach-avs-ethereum-cyber
 

--- a/holesky/mach-avs/altlayer-multi-mach/.env.example
+++ b/holesky/mach-avs/altlayer-multi-mach/.env.example
@@ -5,7 +5,7 @@
 # TODO: use fixed version of image
 MAIN_SERVICE_IMAGE=public.ecr.aws/altlayer/alt-generic-operator:v0.2.1
 MAIN_SERVICE_PROXY_IMAGE=public.ecr.aws/altlayer/mach-operator-proxy:v0.2.3
-MACH_VERIFIER_IMAGE=public.ecr.aws/altlayer/mach:v0.2.1
+MACH_VERIFIER_IMAGE=public.ecr.aws/altlayer/mach:v0.3.1
 
 MACH_SERVICE_NAME=mach-avs-holesky
 


### PR DESCRIPTION
For holesky testnet we upgrade mach (verifier) to v0.3.1 for

- alt avs 
- cyber

Other avs will upgrade in https://github.com/alt-research/mach-avs-operator-setup/pull/39